### PR TITLE
Broadcast mixer: proof of concept

### DIFF
--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -205,6 +205,7 @@ public:
     void            SetPanIsSupported();
     void            SetRemoteFaderIsMute ( const int iChannelIdx, const bool bIsMute );
     void            SetMyChannelID ( const int iChannelIdx ) { iMyChannelID = iChannelIdx; }
+    int             GetMyChannelID () { return iMyChannelID; }
 
     void            SetFaderLevel ( const int iChannelIdx,
                                     const int iValue );

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -387,6 +387,11 @@ void CChannel::SetRemoteBroadcastMixerState (bool eBroadcastMixer) {
     Protocol.CreateBroadcastMixerStateMes( bBroadcastMixer);
 }
 
+void CChannel::CreateFollowMixerBroadcasterMes( bool bFollow, int iBroadcaster)
+{
+    Protocol.CreateFollowBroadcastedMixerMes( bFollow, iBroadcaster );
+}
+
 QString CChannel::GetName()
 {
     // make sure the string is not written at the same time when it is
@@ -562,6 +567,8 @@ void CChannel::OnFollowBroadcastReceived ( bool bIsFollowing, int iChanIdToFollo
         // might just be for the server to handle instead of here, not sure?
         Mutex.unlock();
         emit FollowBroadcastReceived(bIsFollowing, iChanIdToFollow);
+        qInfo() << qUtf8Printable( QString( "channel %1 following %2: %3" )
+            .arg(ChannelInfo.strName).arg( iChanIdToFollow ).arg( bIsFollowing ) );
     }
 }
 

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -121,14 +121,14 @@ qRegisterMetaType<CHostAddress> ( "CHostAddress" );
     QObject::connect ( &Protocol, &CProtocol::VersionAndOSReceived,
         this, &CChannel::OnVersionAndOSReceived );
 
-    // QObject::connect ( &Protocol, &CProtocol::BroadcastMixerStateReceived,
-    //     this, &CChannel::OnBroadcastMixerStateReceived );
+    QObject::connect ( &Protocol, &CProtocol::BroadcastMixerStateReceived,
+        this, &CChannel::OnBroadcastMixerStateReceived );
 
-    // QObject::connect ( &Protocol, &CProtocol::MixerBroadcastersListReceived,
-    //     this, &CChannel::OnMixerBroadcastersListReceived );
+    QObject::connect ( &Protocol, &CProtocol::MixerBroadcastersListReceived,
+        this, &CChannel::MixerBroadcastersListReceived );
 
-    // QObject::connect ( &Protocol, &CProtocol::FollowBroadcastReceived,
-    //     this, &CChannel::OnFollowBroadcastReceived );
+    QObject::connect ( &Protocol, &CProtocol::FollowBroadcastReceived,
+        this, &CChannel::OnFollowBroadcastReceived );
 
     QObject::connect ( &Protocol, &CProtocol::RecorderStateReceived,
         this, &CChannel::RecorderStateReceived );
@@ -533,6 +533,35 @@ void CChannel::OnNetTranspPropsReceived ( CNetworkTransportProps NetworkTranspor
             MutexConvBuf.unlock();
         }
         Mutex.unlock();
+    }
+}
+
+void CChannel::OnBroadcastMixerStateReceived ( bool eIsBroadcastingMixer ) {
+     // only the server shall act on mixer broadcast state received
+    if ( bIsServer ) {
+        Mutex.lock();
+        bBroadcastMixer = eIsBroadcastingMixer;
+
+
+        Mutex.unlock();
+        //TODO: emit event for server to process
+        // output regirstation result/update on the console
+        qInfo() << qUtf8Printable( QString( "mixer broadcasting state received: %1" )
+            .arg( eIsBroadcastingMixer ) );
+        emit BroadcastMixerStateReceived(eIsBroadcastingMixer);
+    }
+}
+
+void CChannel::OnFollowBroadcastReceived ( bool bIsFollowing, int iChanIdToFollow ) {
+    // only the server shall act on mixer broadcast state received
+    if ( bIsServer ) {
+        Mutex.lock();
+        //TODO: first implementing broadcasting, following later
+        // should store that the client is following a specific channel
+        // then send an event to the Server.
+        // might just be for the server to handle instead of here, not sure?
+        Mutex.unlock();
+        emit FollowBroadcastReceived(bIsFollowing, iChanIdToFollow);
     }
 }
 

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -330,7 +330,8 @@ void CChannel::SetGain ( const int   iChanID,
         {
             emit MuteStateHasChanged ( iChanID, true );
         }
-        if ( bBroadcastMixer ) {
+        if ( ( bIsServer && bBroadcastMixer) ||
+             ( !bIsServer && bFollowMixer ) ) {
             // TODO: this single could just be ChangeChanGain, and always be emitted
             // then the separate MuteStateHasChanged could be the same signal.
             // decide on what is best
@@ -364,12 +365,15 @@ void CChannel::SetPan ( const int   iChanID,
     // set value (make sure channel ID is in range)
     if ( ( iChanID >= 0 ) && ( iChanID < MAX_NUM_CHANNELS ) )
     {
-        if ( bBroadcastMixer ) {
+        if ( ( bIsServer && bBroadcastMixer) ||
+             ( !bIsServer && bFollowMixer ) ) {
             // TODO: this single could just be ChangeChanGain, and always be emitted
             // then the separate MuteStateHasChanged could be the same signal.
             // decide on what is best
+            // OTOH, check if possibly this could lead to endless loops.
             emit ChangeBroadcastedChanPan ( iChanID, fNewPan );
         }
+
         vecfPannings[iChanID] = fNewPan;
     }
 }
@@ -480,15 +484,13 @@ void CChannel::OnJittBufSizeChange ( int iNewJitBufSize )
 void CChannel::OnChangeChanGain ( int   iChanID,
                                   float fNewGain )
 {
-    qInfo() << "received gain change";
     SetGain ( iChanID, fNewGain );
 }
 
 void CChannel::OnChangeChanPan ( int   iChanID,
                                  float fNewPan )
 {
-    qInfo() << "received pan change";
-    SetPan ( iChanID, fNewPan );
+    SetPan ( iChanID, fNewPan );    
 }
 
 void CChannel::OnChangeChanInfo ( CChannelCoreInfo ChanInfo )

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -28,7 +28,7 @@
 // CChannel implementation *****************************************************
 CChannel::CChannel ( const bool bNIsServer ) :
     vecfGains              ( MAX_NUM_CHANNELS, 1.0f ),
-    vecfPannings           ( MAX_NUM_CHANNELS, 0.5f ),
+    vecfPannings           ( MAX_NUM_CHANNELS, 0.5f ),    
     iCurSockBufNumFrames   ( INVALID_INDEX ),
     bDoAutoSockBufSize     ( true ),
     bUseSequenceNumber     ( false ), // this is important since in the client we reset on Channel.SetEnable ( false )
@@ -38,7 +38,10 @@ CChannel::CChannel ( const bool bNIsServer ) :
     bIsEnabled             ( false ),
     bIsServer              ( bNIsServer ),
     iAudioFrameSizeSamples ( DOUBLE_SYSTEM_FRAME_SIZE_SAMPLES ),
-    SignalLevelMeter       ( false, 0.5 ) // server mode with mono out and faster smoothing
+    SignalLevelMeter       ( false, 0.5 ), // server mode with mono out and faster smoothing    
+    bBroadcastMixer        ( false ),
+    bFollowMixer           ( false ),
+    iFollowMixerChannel    ( 0 )
 {
     // reset network transport properties
     ResetNetworkTransportProperties();
@@ -117,6 +120,15 @@ qRegisterMetaType<CHostAddress> ( "CHostAddress" );
 
     QObject::connect ( &Protocol, &CProtocol::VersionAndOSReceived,
         this, &CChannel::OnVersionAndOSReceived );
+
+    // QObject::connect ( &Protocol, &CProtocol::BroadcastMixerStateReceived,
+    //     this, &CChannel::OnBroadcastMixerStateReceived );
+
+    // QObject::connect ( &Protocol, &CProtocol::MixerBroadcastersListReceived,
+    //     this, &CChannel::OnMixerBroadcastersListReceived );
+
+    // QObject::connect ( &Protocol, &CProtocol::FollowBroadcastReceived,
+    //     this, &CChannel::OnFollowBroadcastReceived );
 
     QObject::connect ( &Protocol, &CProtocol::RecorderStateReceived,
         this, &CChannel::RecorderStateReceived );
@@ -368,6 +380,11 @@ void CChannel::SetChanInfo ( const CChannelCoreInfo& NChanInf )
         // fire message that the channel info has changed
         emit ChanInfoHasChanged();
     }
+}
+
+void CChannel::SetRemoteBroadcastMixerState (bool eBroadcastMixer) {
+    bBroadcastMixer = eBroadcastMixer;
+    Protocol.CreateBroadcastMixerStateMes( bBroadcastMixer);
 }
 
 QString CChannel::GetName()

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -599,21 +599,19 @@ void CChannel::OnBroadcastMixerStateReceived ( bool eIsBroadcastingMixer ) {
 }
 
 void CChannel::OnFollowBroadcastReceived ( bool eIsFollowing, int eChanIdToFollow ) {
-    // only the server shall act on mixer broadcast state received
-    if ( bIsServer ) {
-        Mutex.lock();
-        //TODO: first implementing broadcasting, following later
-        // should store that the client is following a specific channel
-        // then send an event to the Server.
-        // might just be for the server to handle instead of here, not sure?
-        bFollowMixer = eIsFollowing;
-        iFollowMixerChannel = eChanIdToFollow;
+   // client can follow, server can indicate that the client is no longer following
+    Mutex.lock();
+    //TODO: first implementing broadcasting, following later
+    // should store that the client is following a specific channel
+    // then send an event to the Server.
+    // might just be for the server to handle instead of here, not sure?
+    bFollowMixer = eIsFollowing;
+    iFollowMixerChannel = eChanIdToFollow;
 
-        Mutex.unlock();
-        emit FollowBroadcastReceived(bFollowMixer, iFollowMixerChannel);
-        qInfo() << qUtf8Printable( QString( "channel %1 following %2: %3" )
-            .arg(ChannelInfo.strName).arg( iFollowMixerChannel ).arg( bFollowMixer ) );
-    }
+    Mutex.unlock();
+    emit FollowBroadcastReceived(bFollowMixer, iFollowMixerChannel);
+    qInfo() << qUtf8Printable( QString( "channel %1 following %2: %3" )
+        .arg(ChannelInfo.strName).arg( iFollowMixerChannel ).arg( bFollowMixer ) );
 }
 
 void CChannel::OnReqNetTranspProps()

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -330,6 +330,12 @@ void CChannel::SetGain ( const int   iChanID,
         {
             emit MuteStateHasChanged ( iChanID, true );
         }
+        if ( bBroadcastMixer ) {
+            // TODO: this single could just be ChangeChanGain, and always be emitted
+            // then the separate MuteStateHasChanged could be the same signal.
+            // decide on what is best
+            emit ChangeBroadcastedChanGain ( iChanID, fNewGain );
+        }
 
         vecfGains[iChanID] = fNewGain;
     }
@@ -358,6 +364,12 @@ void CChannel::SetPan ( const int   iChanID,
     // set value (make sure channel ID is in range)
     if ( ( iChanID >= 0 ) && ( iChanID < MAX_NUM_CHANNELS ) )
     {
+        if ( bBroadcastMixer ) {
+            // TODO: this single could just be ChangeChanGain, and always be emitted
+            // then the separate MuteStateHasChanged could be the same signal.
+            // decide on what is best
+            emit ChangeBroadcastedChanPan ( iChanID, fNewPan );
+        }
         vecfPannings[iChanID] = fNewPan;
     }
 }
@@ -468,17 +480,19 @@ void CChannel::OnJittBufSizeChange ( int iNewJitBufSize )
 void CChannel::OnChangeChanGain ( int   iChanID,
                                   float fNewGain )
 {
+    qInfo() << "received gain change";
     SetGain ( iChanID, fNewGain );
 }
 
 void CChannel::OnChangeChanPan ( int   iChanID,
                                  float fNewPan )
 {
+    qInfo() << "received pan change";
     SetPan ( iChanID, fNewPan );
 }
 
 void CChannel::OnChangeChanInfo ( CChannelCoreInfo ChanInfo )
-{
+{    
     SetChanInfo ( ChanInfo );
 }
 

--- a/src/channel.h
+++ b/src/channel.h
@@ -289,6 +289,9 @@ public slots:
 
     void OnNewConnection() { emit NewConnection(); }
 
+    void OnBroadcastMixerStateReceived ( bool bIsBroadcastingMixer );    
+    void OnFollowBroadcastReceived ( bool bIsFollowing, int iChanIdToFollow );
+
 signals:
     void MessReadyForSending ( CVector<uint8_t> vecMessage );
     void NewConnection();
@@ -306,6 +309,9 @@ signals:
     void ReqNetTranspProps();
     void LicenceRequired ( ELicenceType eLicenceType );
     void VersionAndOSReceived ( COSUtil::EOpSystemType eOSType, QString strVersion );
+    void MixerBroadcastersListReceived(CVector<int> vecBroadcasters);
+    void FollowBroadcastReceived( bool bIsFollowing, int iChanIdToFollow );
+    void BroadcastMixerStateReceived (bool bIsBroadcasting);
     void RecorderStateReceived ( ERecorderState eRecorderState );
     void Disconnected();
 

--- a/src/channel.h
+++ b/src/channel.h
@@ -113,6 +113,7 @@ public:
     void CreateVersionAndOSMes() { Protocol.CreateVersionAndOSMes(); }
     void CreateMuteStateHasChangedMes ( const int iChanID, const bool bIsMuted ) { Protocol.CreateMuteStateHasChangedMes ( iChanID, bIsMuted ); }
     void CreateMixerBroadcastersListMes(CVector<int> broadcasters) { Protocol.CreateBroadcastMixerStateListMes( broadcasters ); }
+    void CreateFollowMixerBroadcasterMes( bool bFollow, int iBroadcaster );
 
     void SetGain ( const int iChanID, const float fNewGain );
     float GetGain ( const int iChanID );

--- a/src/channel.h
+++ b/src/channel.h
@@ -318,6 +318,8 @@ signals:
     void MixerBroadcastersListReceived(CVector<int> vecBroadcasters);
     void FollowBroadcastReceived( bool bIsFollowing, int iChanIdToFollow );
     void BroadcastMixerStateReceived (bool bIsBroadcasting);
+    void ChangeBroadcastedChanGain ( int iChanID, float fNewGain );
+    void ChangeBroadcastedChanPan ( int iChanID, float fNewPan );
     void RecorderStateReceived ( ERecorderState eRecorderState );
     void Disconnected();
 

--- a/src/channel.h
+++ b/src/channel.h
@@ -106,6 +106,8 @@ public:
     void SetRemoteInfo ( const CChannelCoreInfo ChInfo )
         { Protocol.CreateChanInfoMes ( ChInfo ); }
 
+    void SetRemoteBroadcastMixerState (bool bBroadcastMixer);
+
     void CreateReqChanInfoMes() { Protocol.CreateReqChanInfoMes(); }
     void CreateVersionAndOSMes() { Protocol.CreateVersionAndOSMes(); }
     void CreateMuteStateHasChangedMes ( const int iChanID, const bool bIsMuted ) { Protocol.CreateMuteStateHasChangedMes ( iChanID, bIsMuted ); }
@@ -220,6 +222,11 @@ protected:
 
     // network protocol
     CProtocol               Protocol;
+
+    //mixer state broadcasting
+    bool                    bBroadcastMixer;
+    bool                    bFollowMixer;
+    int                     iFollowMixerChannel;
 
     int                     iConTimeOut;
     int                     iConTimeOutStartVal;

--- a/src/channel.h
+++ b/src/channel.h
@@ -93,7 +93,10 @@ public:
 
     void SetEnable ( const bool bNEnStat );
     bool IsEnabled() { return bIsEnabled; }
-    bool IsBroadcastingMixer() { return bBroadcastMixer; }
+
+    bool IsBroadcastingMixer();
+    bool IsFollowingMixer();
+    int GetFollowingMixerChannel();
 
     void SetAddress ( const CHostAddress NAddr ) { InetAddr = NAddr; }
     bool GetAddress ( CHostAddress& RetAddr );

--- a/src/channel.h
+++ b/src/channel.h
@@ -93,6 +93,7 @@ public:
 
     void SetEnable ( const bool bNEnStat );
     bool IsEnabled() { return bIsEnabled; }
+    bool IsBroadcastingMixer() { return bBroadcastMixer; }
 
     void SetAddress ( const CHostAddress NAddr ) { InetAddr = NAddr; }
     bool GetAddress ( CHostAddress& RetAddr );
@@ -111,6 +112,7 @@ public:
     void CreateReqChanInfoMes() { Protocol.CreateReqChanInfoMes(); }
     void CreateVersionAndOSMes() { Protocol.CreateVersionAndOSMes(); }
     void CreateMuteStateHasChangedMes ( const int iChanID, const bool bIsMuted ) { Protocol.CreateMuteStateHasChangedMes ( iChanID, bIsMuted ); }
+    void CreateMixerBroadcastersListMes(CVector<int> broadcasters) { Protocol.CreateBroadcastMixerStateListMes( broadcasters ); }
 
     void SetGain ( const int iChanID, const float fNewGain );
     float GetGain ( const int iChanID );

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -63,6 +63,7 @@ CClient::CClient ( const quint16  iPortNumber,
     bEnableOPUS64                    ( false ),
     bJitterBufferOK                  ( true ),
     bNuteMeInPersonalMix             ( bNMuteMeInPersonalMix ),
+    bBroadcastMixer                  ( false ),
     iServerSockBufNumFrames          ( DEF_NET_BUF_SIZE_NUM_BL ),
     pSignalHandler                   ( CSignalHandler::getSingletonP() )
 {
@@ -624,6 +625,11 @@ void CClient::SetSndCrdRightOutputChannel ( const int iNewChan )
         // restart client
         Sound.Start();
     }
+}
+
+void CClient::SetBroadcastMixer(const bool eBroadcastMixer) {
+    bBroadcastMixer = eBroadcastMixer;
+    Channel.SetRemoteBroadcastMixerState(bBroadcastMixer);
 }
 
 void CClient::OnSndCrdReinitRequest ( int iSndCrdResetType )

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -149,6 +149,9 @@ CClient::CClient ( const quint16  iPortNumber,
     QObject::connect ( &Channel, &CChannel::VersionAndOSReceived,
         this, &CClient::VersionAndOSReceived );
 
+    QObject::connect ( &Channel, &CChannel::MixerBroadcastersListReceived,
+        this, &CClient::OnMixerBroadcastersListReceived );
+
     QObject::connect ( &Channel, &CChannel::RecorderStateReceived,
         this, &CClient::RecorderStateReceived );
 
@@ -771,6 +774,21 @@ void CClient::OnClientIDReceived ( int iChanID )
     }
 
     emit ClientIDReceived ( iChanID );
+}
+
+void CClient::OnMixerBroadcastersListReceived(CVector<int> vecBroadcasters)
+{
+    qInfo() << qUtf8Printable( QString( "received broadcasters list" ) );
+    qInfo() << vecBroadcasters.Size();
+
+    if (!Channel.IsBroadcastingMixer() && vecBroadcasters.Size() > 0 ) {
+        //TODO: replace with a UI Element OR store state so that it auto follows a broadcaster with a give name
+        //OR the broadcaster with the lowest channel number?
+        qInfo() << qUtf8Printable( QString( "following broadcast" ) );
+        Channel.CreateFollowMixerBroadcasterMes( true, vecBroadcasters[0] );
+    } else {
+        qInfo() << qUtf8Printable( QString( "not following broadcast" ) );
+    }
 }
 
 void CClient::Start()

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -782,19 +782,20 @@ void CClient::OnClientIDReceived ( int iChanID )
     emit ClientIDReceived ( iChanID );
 }
 
-void CClient::OnMixerBroadcastersListReceived(CVector<int> vecBroadcasters)
+void CClient::OnMixerBroadcastersListReceived ( CVector<int> vecBroadcasters )
 {
-    qInfo() << qUtf8Printable( QString( "received broadcasters list" ) );
-    qInfo() << vecBroadcasters.Size();
+//    qInfo() << qUtf8Printable( QString( "received broadcasters list" ) );
+//    qInfo() << vecBroadcasters.Size();
 
-    if (!Channel.IsBroadcastingMixer() && vecBroadcasters.Size() > 0 ) {
-        //TODO: replace with a UI Element OR store state so that it auto follows a broadcaster with a give name
-        //OR the broadcaster with the lowest channel number?
-        qInfo() << qUtf8Printable( QString( "following broadcast" ) );
-        Channel.CreateFollowMixerBroadcasterMes( true, vecBroadcasters[0] );
-    } else {
-        qInfo() << qUtf8Printable( QString( "not following broadcast" ) );
-    }
+//    if (!Channel.IsBroadcastingMixer() && vecBroadcasters.Size() > 0 ) {
+//        //TODO: replace with a UI Element OR store state so that it auto follows a broadcaster with a give name
+//        //OR the broadcaster with the lowest channel number?
+//        qInfo() << qUtf8Printable( QString( "following broadcast" ) );
+//        Channel.CreateFollowMixerBroadcasterMes( true, vecBroadcasters[0] );
+//    } else {
+//        qInfo() << qUtf8Printable( QString( "not following broadcast" ) );
+//    }
+    emit MixerBroadcastersListReceived( vecBroadcasters );
 }
 
 void CClient::Start()

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -152,6 +152,12 @@ CClient::CClient ( const quint16  iPortNumber,
     QObject::connect ( &Channel, &CChannel::MixerBroadcastersListReceived,
         this, &CClient::OnMixerBroadcastersListReceived );
 
+    QObject::connect ( &Channel, &CChannel::ChangeBroadcastedChanGain,
+        this, &CClient::ChangeBroadcastedChanGain );
+
+    QObject::connect ( &Channel, &CChannel::ChangeBroadcastedChanPan,
+        this, &CClient::ChangeBroadcastedChanPan );
+
     QObject::connect ( &Channel, &CChannel::RecorderStateReceived,
         this, &CClient::RecorderStateReceived );
 

--- a/src/client.h
+++ b/src/client.h
@@ -142,6 +142,9 @@ public:
     int  GetAudioInFader() const { return iAudioInFader; }
     void SetAudioInFader ( const int iNV ) { iAudioInFader = iNV; }
 
+    bool GetBroadcastMixer() const { return bBroadcastMixer; }
+    void SetBroadcastMixer(const bool eBroadcastMixer);
+
     int  GetReverbLevel() const { return iReverbLevel; }
     void SetReverbLevel ( const int iNL ) { iReverbLevel = iNL; }
 
@@ -359,6 +362,7 @@ protected:
     bool                    bJitterBufferOK;
     bool                    bNuteMeInPersonalMix;
     QMutex                  MutexDriverReinit;
+    bool                    bBroadcastMixer;
 
     // server settings
     int                     iServerSockBufNumFrames;

--- a/src/client.h
+++ b/src/client.h
@@ -402,6 +402,7 @@ protected slots:
     void OnControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
     void OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
     void OnClientIDReceived ( int iChanID );
+    void OnMixerBroadcastersListReceived( CVector<int> vecBroadcasters );
 
 signals:
     void ConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo );

--- a/src/client.h
+++ b/src/client.h
@@ -132,6 +132,13 @@ public:
 
     bool   IsFollowingMixerBroadcast() { return Channel.IsFollowingMixer(); }
 
+    int GetFollowingMixerChannel() { return Channel.GetFollowingMixerChannel(); }
+
+    bool IsBroadcastingMixer() { return Channel.IsBroadcastingMixer(); }
+    void FollowBroadcastingMixer ( bool bFollow, int iChanID ) {
+        Channel.CreateFollowMixerBroadcasterMes( bFollow, iChanID );
+    }
+
     EGUIDesign GetGUIDesign() const { return eGUIDesign; }
     void       SetGUIDesign ( const EGUIDesign eNGD ) { eGUIDesign = eNGD; }
 
@@ -445,4 +452,5 @@ signals:
     void ControllerInPanValue ( int iChannelIdx, int iValue );
     void ControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
     void ControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
+    void MixerBroadcastersListReceived ( CVector<int> vecBroadcasters );
 };

--- a/src/client.h
+++ b/src/client.h
@@ -130,6 +130,8 @@ public:
 
     bool   IsConnected() { return Channel.IsConnected(); }
 
+    bool   IsFollowingMixerBroadcast() { return Channel.IsFollowingMixer(); }
+
     EGUIDesign GetGUIDesign() const { return eGUIDesign; }
     void       SetGUIDesign ( const EGUIDesign eNGD ) { eGUIDesign = eNGD; }
 

--- a/src/client.h
+++ b/src/client.h
@@ -412,6 +412,9 @@ signals:
     void LicenceRequired ( ELicenceType eLicenceType );
     void VersionAndOSReceived ( COSUtil::EOpSystemType eOSType, QString strVersion );
     void PingTimeReceived ( int iPingTime );
+    void ChangeBroadcastedChanGain ( int iChanID, float fGain );
+    void ChangeBroadcastedChanPan ( int iChanID, float fPan );
+
     void RecorderStateReceived ( ERecorderState eRecorderState );
 
     void CLServerListReceived ( CHostAddress         InetAddr,

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -846,18 +846,7 @@ void CClientDlg::OnSaveChannelSetup()
 
 void CClientDlg::OnBroadcastChannelSetup()
 {
-    // QString strFileName = QFileDialog::getSaveFileName ( this,
-    //                                                      tr ( "Select Channel Setup File" ),
-    //                                                      "",
-    //                                                      QString ( "*." ) + MIX_SETTINGS_FILE_SUFFIX );
-
-    // if ( !strFileName.isEmpty() )
-    // {
-    //     // first store all current fader settings (in case we are in an active connection
-    //     // right now) and then save the information in the settings struct in the file
-    //     MainMixerBoard->StoreAllFaderSettings();
-    //     pSettings->SaveFaderSettings ( strFileName );
-    // }
+    pClient->SetBroadcastMixer(true); //TODO: toggle, or create second function/method/procedure/whatever the name is in C++
 }
 
 void CClientDlg::OnVersionAndOSReceived ( COSUtil::EOpSystemType ,

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -254,8 +254,8 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     pFileMenu->addAction ( tr ( "&Save Mixer Channels Setup..." ), this,
         SLOT ( OnSaveChannelSetup() ) );
 
-    pFileMenu->addAction ( tr ( "&Broadcast Mixer to others..." ), this,
-        SLOT ( OnBroadcastChannelSetup() ) );
+    pToggleBroadcastMenuItem = pFileMenu->addAction ( tr ( "&Broadcast Mixer to others..." ), this,
+        SLOT ( OnToggleBroadcast() ) );
 
     pFileMenu->addSeparator();
 
@@ -850,9 +850,18 @@ void CClientDlg::OnSaveChannelSetup()
     }
 }
 
-void CClientDlg::OnBroadcastChannelSetup()
+void CClientDlg::OnToggleBroadcast()
 {
-    pClient->SetBroadcastMixer(true); //TODO: toggle, or create second function/method/procedure/whatever the name is in C++
+    bool bIsBroadcasting = pClient->GetBroadcastMixer();
+    if ( bIsBroadcasting )
+    {
+        //TODO: translation!
+        pToggleBroadcastMenuItem->setText( tr ( "&Broadcast Mixer to others..." )) ;
+    } else
+    {
+        pToggleBroadcastMenuItem->setText( tr ( "&Stop broadcasting Mixer to others..." ) );
+    }
+    pClient->SetBroadcastMixer(!bIsBroadcasting); //TODO: toggle, or create second function/method/procedure/whatever the name is in C++
 }
 
 void CClientDlg::OnVersionAndOSReceived ( COSUtil::EOpSystemType ,

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -468,6 +468,12 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     QObject::connect ( pClient, &CClient::MuteStateHasChangedReceived,
         this, &CClientDlg::OnMuteStateHasChangedReceived );
 
+    QObject::connect ( pClient, &CClient::ChangeBroadcastedChanGain,
+        this, &CClientDlg::OnChangeBroadcastedChanGain );
+
+    QObject::connect ( pClient, &CClient::ChangeBroadcastedChanPan,
+        this, &CClientDlg::OnChangeBroadcastedChanPan );
+
     QObject::connect ( pClient, &CClient::RecorderStateReceived,
         this, &CClientDlg::OnRecorderStateReceived );
 
@@ -1411,6 +1417,16 @@ rbtReverbSelR->setStyleSheet ( "" );
 
     // also apply GUI design to child GUI controls
     MainMixerBoard->SetGUIDesign ( eNewDesign );
+}
+
+void CClientDlg::OnChangeBroadcastedChanGain(int iChanID, float fGain)
+{
+    MainMixerBoard->SetFaderLevel(iChanID, ( int ) MathUtils::CalcFaderValue(fGain) );
+}
+
+void CClientDlg::OnChangeBroadcastedChanPan(int iChanID, float fPan)
+{
+    MainMixerBoard->SetPanValue(iChanID, ( int )  ( fPan * ( float ) AUD_MIX_PAN_MAX ) );
 }
 
 void CClientDlg::OnRecorderStateReceived (  const ERecorderState newRecorderState )

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -254,6 +254,9 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     pFileMenu->addAction ( tr ( "&Save Mixer Channels Setup..." ), this,
         SLOT ( OnSaveChannelSetup() ) );
 
+    pFileMenu->addAction ( tr ( "&Broadcast Mixer to others..." ), this,
+        SLOT ( OnBroadcastChannelSetup() ) );
+
     pFileMenu->addSeparator();
 
     pFileMenu->addAction ( tr ( "E&xit" ), this,
@@ -839,6 +842,22 @@ void CClientDlg::OnSaveChannelSetup()
         MainMixerBoard->StoreAllFaderSettings();
         pSettings->SaveFaderSettings ( strFileName );
     }
+}
+
+void CClientDlg::OnBroadcastChannelSetup()
+{
+    // QString strFileName = QFileDialog::getSaveFileName ( this,
+    //                                                      tr ( "Select Channel Setup File" ),
+    //                                                      "",
+    //                                                      QString ( "*." ) + MIX_SETTINGS_FILE_SUFFIX );
+
+    // if ( !strFileName.isEmpty() )
+    // {
+    //     // first store all current fader settings (in case we are in an active connection
+    //     // right now) and then save the information in the settings struct in the file
+    //     MainMixerBoard->StoreAllFaderSettings();
+    //     pSettings->SaveFaderSettings ( strFileName );
+    // }
 }
 
 void CClientDlg::OnVersionAndOSReceived ( COSUtil::EOpSystemType ,

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -164,6 +164,7 @@ public slots:
 
     void OnLoadChannelSetup();
     void OnSaveChannelSetup();
+    void OnBroadcastChannelSetup();
     void OnOpenConnectionSetupDialog() { ShowConnectionSetupDialog(); }
     void OnOpenMusicianProfileDialog() { ShowMusicianProfileDialog(); }
     void OnOpenGeneralSettings() { ShowGeneralSettings(); }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -113,6 +113,7 @@ protected:
     QTimer             TimerStatus;
     QTimer             TimerPing;
     QTimer             TimerCheckAudioDeviceOk;
+    int                iFirstBroadcaster;
 
     virtual void       closeEvent     ( QCloseEvent*     Event );
     virtual void       dragEnterEvent ( QDragEnterEvent* Event ) { ManageDragNDrop ( Event, true ); }
@@ -251,10 +252,14 @@ public slots:
     void OnGUIDesignChanged();
     void OnChangeBroadcastedChanGain( int iChanID, float fGain );
     void OnChangeBroadcastedChanPan( int iChanID, float fPan );
+    void OnMixerBroadcastersListReceived( CVector<int> broadcasters );
     void OnRecorderStateReceived ( ERecorderState eRecorderState );
     void SetMixerBoardDeco(  const ERecorderState newRecorderState, const EGUIDesign eNewDesign  );
     void OnAudioChannelsChanged() { UpdateRevSelection(); }
     void OnNumClientsChanged ( int iNewNumClients );
+
+    //TODO: properly introduce follow checkbox class that stores its channel number
+    void OnFollowStateChange ( int state );
 
     void accept() { close(); } // introduced by pljones
 };

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -246,6 +246,8 @@ public slots:
     void OnConnectDlgAccepted();
     void OnDisconnected() { Disconnect(); }
     void OnGUIDesignChanged();
+    void OnChangeBroadcastedChanGain( int iChanID, float fGain );
+    void OnChangeBroadcastedChanPan( int iChanID, float fPan );
     void OnRecorderStateReceived ( ERecorderState eRecorderState );
     void SetMixerBoardDeco(  const ERecorderState newRecorderState, const EGUIDesign eNewDesign  );
     void OnAudioChannelsChanged() { UpdateRevSelection(); }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -125,6 +125,9 @@ protected:
     CAnalyzerConsole   AnalyzerConsole;
     CMusProfDlg        MusicianProfileDlg;
 
+    QAction* pToggleBroadcastMenuItem;
+
+
 public slots:
     void OnConnectDisconBut();
     void OnTimerSigMet();
@@ -164,7 +167,7 @@ public slots:
 
     void OnLoadChannelSetup();
     void OnSaveChannelSetup();
-    void OnBroadcastChannelSetup();
+    void OnToggleBroadcast();
     void OnOpenConnectionSetupDialog() { ShowConnectionSetupDialog(); }
     void OnOpenMusicianProfileDialog() { ShowMusicianProfileDialog(); }
     void OnOpenGeneralSettings() { ShowGeneralSettings(); }

--- a/src/clientdlgbase.ui
+++ b/src/clientdlgbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>425</width>
+    <width>647</width>
     <height>490</height>
    </rect>
   </property>
@@ -41,6 +41,9 @@
    </property>
    <item>
     <widget class="QFrame" name="backgroundFrame">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -589,6 +592,9 @@
            </widget>
           </item>
          </layout>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="followGrid"/>
         </item>
         <item>
          <widget class="CAudioMixerBoard" name="MainMixerBoard" native="true">

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -228,6 +228,24 @@ MESSAGES (with connection)
     | 1 byte operating system | 2 bytes number n | n bytes UTF-8 string version |
     +-------------------------+------------------+------------------------------+
 
+- PROTMESSID_BROADCAST_MIXER_STATE: Set the mixer state for a single channel
+
+    +-------------------+------------------------------+
+    | 1 byte channel ID | 1 byte broadcast enabled/disabled |
+    +-------------------+------------------------------+
+
+- PROTMESSID_BROADCAST_MIXER_STATE_LIST: A list of channels that are broadcasting their mix
+
+    for each channel that is broadcasting, will contain a 1 byte channel id
+    if nobody is broadcasting, contains no data, n = 0
+
+- PROTMESSID_FOLLOW_BROADCASTED_MIXER: Indicate which mixer to follow, or to unfollow
+
+    +-------------------+--------------------------------------------------------------+
+    | 1 byte channel ID | 1 byte client wants to follow | 1 byte channel id to follow  |
+    +-------------------+--------------------------------------------------------------+
+
+
 
 // #### COMPATIBILITY OLD VERSION, TO BE REMOVED ####
 - PROTMESSID_OPUS_SUPPORTED: Informs that OPUS codec is supported

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -230,9 +230,9 @@ MESSAGES (with connection)
 
 - PROTMESSID_BROADCAST_MIXER_STATE: Set the mixer state for a single channel
 
-    +-------------------+------------------------------+
+    +-------------------+-----------------------------------+
     | 1 byte channel ID | 1 byte broadcast enabled/disabled |
-    +-------------------+------------------------------+
+    +-------------------+-----------------------------------+
 
 - PROTMESSID_BROADCAST_MIXER_STATE_LIST: A list of channels that are broadcasting their mix
 
@@ -861,10 +861,20 @@ if ( rand() < ( RAND_MAX / 2 ) ) return false;
                 case PROTMESSID_VERSION_AND_OS:
                     EvaluateVersionAndOSMes ( vecbyMesBodyDataRef );
                     break;
+                case PROTMESSID_BROADCAST_MIXER_STATE:
+                    EvaluateBroadcastMixerStateMes(vecbyMesBodyDataRef);
+                    break;
+                case PROTMESSID_BROADCAST_MIXER_STATE_LIST:
+                    EvaluateBroadcastMixerStateListMes(vecbyMesBodyDataRef);
+                    break;
+                case PROTMESSID_FOLLOW_BROADCASTED_MIXER: 
+                    EvaluateFollowBroadcastedMixerMes(vecbyMesBodyDataRef);
+                    break;
 
                 case PROTMESSID_RECORDER_STATE:
                     EvaluateRecorderStateMes ( vecbyMesBodyDataRef );
                     break;
+                    
                 }
             }
 
@@ -1744,6 +1754,90 @@ bool CProtocol::EvaluateVersionAndOSMes ( const CVector<uint8_t>& vecData )
 
     // invoke message action
     emit VersionAndOSReceived ( eOSType, strVersion );
+
+    return false; // no error
+}
+
+void CProtocol::CreateBroadcastMixerStateMes(const bool bIsBroadcastingMixer) {
+    CVector<uint8_t> vecData ( 1 ); // 1 byte of data
+    int              iPos = 0;      // init position pointer
+    PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( bIsBroadcastingMixer ), 1 );
+    CreateAndSendMessage ( PROTMESSID_BROADCAST_MIXER_STATE, vecData );
+}
+       
+bool CProtocol::EvaluateBroadcastMixerStateMes (const CVector<uint8_t>& vecData) {
+    int iPos = 0; // init position pointer
+
+    // check size
+    if ( vecData.Size() != 1 )
+    {
+        return true; // return error code
+    }
+
+    const int bIsBroadcastingMixer =
+        static_cast<bool> ( GetValFromStream ( vecData, iPos, 1 ) );
+
+    // invoke message action
+    emit BroadcastMixerStateReceived ( bIsBroadcastingMixer);
+
+    return false; // no error
+}
+
+void CProtocol::CreateBroadcastMixerStateListMes(const CVector<int> broadcasters) {
+    CVector<uint8_t> vecData ( broadcasters.Size() );
+    int              iPos = 0;      // init position pointer
+    for ( int i = 0; i < broadcasters.Size(); i++ ) {
+        PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( broadcasters[i] ), 1 );
+    }
+    CreateAndSendMessage ( PROTMESSID_BROADCAST_MIXER_STATE_LIST, vecData );
+}
+
+bool CProtocol::EvaluateBroadcastMixerStateListMes(const CVector<uint8_t>& vecData) {
+    CVector<int> broadcasters (vecData.Size());
+    int iPos = 0; // init position pointer
+
+
+    for ( int i = 0; i < broadcasters.Size(); i++ ) {
+        broadcasters[i] = static_cast<int> ( GetValFromStream ( vecData, iPos, 1 ) );
+    }            
+
+    // invoke message action
+    emit MixerBroadcastersListReceived (broadcasters);
+
+    return false; // no error
+}
+
+void CProtocol::CreateFollowBroadcastedMixerMes(const bool bIsFollowing, const int iChanIdToFollow) {
+    CVector<uint8_t> vecData ( 2 ); // 1 byte of data
+    int              iPos = 0;      // init position pointer
+    // build data vector
+    //whether to follow or not
+    PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( bIsFollowing ), 1 );
+    //channel id to follow
+    PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( iChanIdToFollow ), 1 );
+    CreateAndSendMessage ( PROTMESSID_FOLLOW_BROADCASTED_MIXER, vecData );
+
+}
+
+bool CProtocol::EvaluateFollowBroadcastedMixerMes(const CVector<uint8_t>& vecData) {
+    int iPos = 0; // init position pointer
+
+    // check size
+    if ( vecData.Size() != 2 )
+    {
+        return true; // return error code
+    }
+
+    // channel id, 1 byte
+    const int bIsFollowing =
+        static_cast<bool> ( GetValFromStream ( vecData, iPos, 1 ) );
+    const int iChanIdToFollow =
+        static_cast<int> ( GetValFromStream ( vecData, iPos, 1 ) );
+
+    
+
+    // invoke message action
+    emit FollowBroadcastReceived ( bIsFollowing, iChanIdToFollow );
 
     return false; // no error
 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -63,6 +63,9 @@
 #define PROTMESSID_RECORDER_STATE             33 // contains the state of the jam recorder (ERecorderState)
 #define PROTMESSID_REQ_SPLIT_MESS_SUPPORT     34 // request support for split messages
 #define PROTMESSID_SPLIT_MESS_SUPPORTED       35 // split messages are supported
+#define PROTMESSID_BROADCAST_MIXER_STATE      38 // Set the broadcast mixer to others state
+#define PROTMESSID_BROADCAST_MIXER_STATE_LIST 39 // A list of broadcast mixer states
+#define PROTMESSID_FOLLOW_BROADCASTED_MIXER   40 // follow or unfollow someone elses mixer state
 
 // message IDs of connection less messages (CLM)
 // DEFINITION -> start at 1000, end at 1999, see IsConnectionLessMessageID

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -136,6 +136,10 @@ public:
 void CreateReqChannelLevelListMes();
 
     void CreateVersionAndOSMes();
+    void CreateBroadcastMixerStateMes(const bool bIsBroadcastingMixer);
+    void CreateBroadcastMixerStateListMes(const CVector<int> broadcasters);
+    void CreateFollowBroadcastedMixerMes(const bool bIsFollowing, const int iChanIdToFollow);
+
     void CreateRecorderStateMes ( const ERecorderState eRecorderState );
 
     void CreateCLPingMes               ( const CHostAddress& InetAddr, const int iMs );
@@ -286,6 +290,9 @@ protected:
     bool EvaluateSplitMessSupportedMes();
     bool EvaluateLicenceRequiredMes     ( const CVector<uint8_t>& vecData );
     bool EvaluateVersionAndOSMes        ( const CVector<uint8_t>& vecData );
+    bool EvaluateBroadcastMixerStateMes (const CVector<uint8_t>& vecData);
+    bool EvaluateBroadcastMixerStateListMes(const CVector<uint8_t>& vecData);
+    bool EvaluateFollowBroadcastedMixerMes(const CVector<uint8_t>& vecData);
     bool EvaluateRecorderStateMes       ( const CVector<uint8_t>& vecData );
 
     bool EvaluateCLPingMes               ( const CHostAddress&     InetAddr,
@@ -360,6 +367,9 @@ signals:
     void SplitMessSupported();
     void LicenceRequired ( ELicenceType eLicenceType );
     void VersionAndOSReceived ( COSUtil::EOpSystemType eOSType, QString strVersion );
+    void BroadcastMixerStateReceived ( bool bIsBroadcastingMixer );
+    void MixerBroadcastersListReceived(CVector<int> vecBroadcasters);
+    void FollowBroadcastReceived ( bool bIsFollowing, int iChanIdToFollow );
     void RecorderStateReceived ( ERecorderState eRecorderState );
 
     void CLPingReceived               ( CHostAddress           InetAddr,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1478,12 +1478,16 @@ void CServer::CreateAndSendBroadcastersListForAllConChannels()
     // create broadcasters list
     CVector<int> vecBroadcastersList ( CreateBroadcastersList() );
 
+    qInfo() << "creating and sending broadcasters list";
+    qInfo() << vecBroadcastersList.Size();
+
     // now send connected channels list to all connected clients
     for ( int i = 0; i < iMaxNumChannels; i++ )
     {
         if ( vecChannels[i].IsConnected() )
         {
             // send message
+            qInfo() << "creating and sending broadcasters list message ";
             vecChannels[i].CreateMixerBroadcastersListMes ( vecBroadcastersList );
         }
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -657,7 +657,8 @@ void CServer::OnNewConnection ( int          iChID,
     // in case the client thinks he is still connected but the server
     // was restartet, it is important that we send the channel list
     // at this place.
-    vecChannels[iChID].CreateReqChanInfoMes();
+    vecChannels[iChID].CreateReqChanInfoMes();    
+
 
     // send welcome message (if enabled)
     MutexWelcomeMessage.lock();
@@ -685,6 +686,14 @@ void CServer::OnNewConnection ( int          iChID,
 
     // send recording state message on connection
     vecChannels[iChID].CreateRecorderStateMes ( JamController.GetRecorderState() );
+
+    // create broadcasters list
+    CVector<int> vecBroadcastersList ( CreateBroadcastersList() );
+    // send the broadcasters list to every new connection
+    vecChannels[iChID].CreateMixerBroadcastersListMes( vecBroadcastersList );
+    //TODO: request the mixer broadcast state, which will automatically trigger sending this to all clients if someting has changed, instaed of this
+    // otherwise a restart will lose sync on broadcast state
+    // may need a new REQ_MIXER_BROADCAST_STATE message?
 
     // reset the conversion buffers
     DoubleFrameSizeConvBufIn[iChID].Reset();

--- a/src/server.h
+++ b/src/server.h
@@ -141,10 +141,18 @@ public:
         CreateAndSendJitBufMessage ( slotId - 1, iNNumFra );
     }
 
-    void OnBroadcastMixerStateReceived( bool bIsBroadcastingMixer )
+    void OnBroadcastMixerStateReceived ( bool bIsBroadcastingMixer )
     {
         //TODO: if ( !bIsBroadcastingMixer ) { RemoveAllFollowersForThisServerSlot(); }
         CreateAndSendBroadcastersListForAllConChannels();
+    }
+
+    void OnChangeBroadcastedChanPan ( int iChanId, float fPan) {
+        CreateAndSendChanPanToAllFollowers ( slotId - 1, iChanId, fPan);
+    }
+
+    void OnChangeBroadcastedChanGain ( int iChanId, float fGain) {
+        CreateAndSendChanGainToAllFollowers ( slotId - 1, iChanId, fGain);
     }
 
 protected:
@@ -163,7 +171,16 @@ protected:
     virtual void CreateAndSendJitBufMessage ( const int iCurChanID,
                                               const int iNNumFra ) = 0;
 
-    virtual void CreateAndSendBroadcastersListForAllConChannels();
+    virtual void CreateAndSendBroadcastersListForAllConChannels() = 0;
+
+    //TODO: check if this is required here, and why. Last touched C++ templates at least 15 years ago
+    virtual void CreateAndSendChanPanToAllFollowers ( const int  iBroadcasterChanID,
+                                                      const int  iOtherChanID,
+                                                      const float fPan ) = 0;
+
+    virtual void CreateAndSendChanGainToAllFollowers ( const int  iBroadcasterChanID,
+                                                      const int  iOtherChanID,
+                                                      const float fGain ) = 0;
 };
 
 template<>
@@ -299,6 +316,13 @@ protected:
     virtual void CreateAndSendChanListForThisChan ( const int iCurChanID );
 
     virtual void CreateAndSendBroadcastersListForAllConChannels();
+    virtual void CreateAndSendChanPanToAllFollowers ( const int  iBroadcasterChanID,
+                                                      const int  iOtherChanID,
+                                                      const float fPan );
+
+    virtual void CreateAndSendChanGainToAllFollowers ( const int  iBroadcasterChanID,
+                                                      const int  iOtherChanID,
+                                                      const float fGain );
     virtual void CreateAndSendChatTextForAllConChannels ( const int      iCurChanID,
                                                           const QString& strChatText );
 

--- a/src/server.h
+++ b/src/server.h
@@ -147,6 +147,12 @@ public:
         CreateAndSendBroadcastersListForAllConChannels();
     }
 
+    void OnFollowBroadcastReceived ( bool bFollowMixer, int iBroadcastingChanID) {
+        if ( bFollowMixer ) {
+            CreateAndSendChanPanGainToNewFollower ( slotId - 1, iBroadcastingChanID );
+        }
+    }
+
     void OnChangeBroadcastedChanPan ( int iChanId, float fPan) {
         CreateAndSendChanPanToAllFollowers ( slotId - 1, iChanId, fPan);
     }
@@ -173,13 +179,16 @@ protected:
 
     virtual void CreateAndSendBroadcastersListForAllConChannels() = 0;
 
+    virtual void CreateAndSendChanPanGainToNewFollower( const int  iFollowerChanID,
+                                                        const int  iBroadcasterChanID ) = 0;
+
     //TODO: check if this is required here, and why. Last touched C++ templates at least 15 years ago
-    virtual void CreateAndSendChanPanToAllFollowers ( const int  iBroadcasterChanID,
-                                                      const int  iOtherChanID,
+    virtual void CreateAndSendChanPanToAllFollowers ( const int   iBroadcasterChanID,
+                                                      const int   iOtherChanID,
                                                       const float fPan ) = 0;
 
     virtual void CreateAndSendChanGainToAllFollowers ( const int  iBroadcasterChanID,
-                                                      const int  iOtherChanID,
+                                                      const int   iOtherChanID,
                                                       const float fGain ) = 0;
 };
 
@@ -316,6 +325,8 @@ protected:
     virtual void CreateAndSendChanListForThisChan ( const int iCurChanID );
 
     virtual void CreateAndSendBroadcastersListForAllConChannels();
+    virtual void CreateAndSendChanPanGainToNewFollower ( const int iBroadcasterChanID,
+                                                         const int iFollowerChanID );
     virtual void CreateAndSendChanPanToAllFollowers ( const int  iBroadcasterChanID,
                                                       const int  iOtherChanID,
                                                       const float fPan );

--- a/src/server.h
+++ b/src/server.h
@@ -143,6 +143,7 @@ public:
 
     void OnBroadcastMixerStateReceived( bool bIsBroadcastingMixer )
     {
+        //TODO: if ( !bIsBroadcastingMixer ) { RemoveAllFollowersForThisServerSlot(); }
         CreateAndSendBroadcastersListForAllConChannels();
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -141,6 +141,11 @@ public:
         CreateAndSendJitBufMessage ( slotId - 1, iNNumFra );
     }
 
+    void OnBroadcastMixerStateReceived( bool bIsBroadcastingMixer )
+    {
+        CreateAndSendBroadcastersListForAllConChannels();
+    }
+
 protected:
     virtual void SendProtMessage ( int              iChID,
                                    CVector<uint8_t> vecMessage ) = 0;
@@ -156,6 +161,8 @@ protected:
 
     virtual void CreateAndSendJitBufMessage ( const int iCurChanID,
                                               const int iNNumFra ) = 0;
+
+    virtual void CreateAndSendBroadcastersListForAllConChannels();
 };
 
 template<>
@@ -285,10 +292,12 @@ protected:
     int FindChannel ( const CHostAddress& CheckAddr );
     int GetNumberOfConnectedClients();
     CVector<CChannelInfo> CreateChannelList();
+    CVector<int> CreateBroadcastersList();
 
     virtual void CreateAndSendChanListForAllConChannels();
     virtual void CreateAndSendChanListForThisChan ( const int iCurChanID );
 
+    virtual void CreateAndSendBroadcastersListForAllConChannels();
     virtual void CreateAndSendChatTextForAllConChannels ( const int      iCurChanID,
                                                           const QString& strChatText );
 

--- a/src/server.h
+++ b/src/server.h
@@ -387,6 +387,9 @@ protected:
     // Channel levels
     CVector<uint16_t>          vecChannelLevels;
 
+    // mixer broadcast following
+    CVector<int>               vecMixerFollowers;
+
     // actual working objects
     CHighPrioSocket            Socket;
 

--- a/src/util.h
+++ b/src/util.h
@@ -1286,6 +1286,19 @@ public:
                 AUD_MIX_FADER_RANGE_DB / 20.0f );
         }
     }
+
+    // calculate fader value in dB from linear gain
+    static float CalcFaderValue ( const float fValue )
+    {
+
+        // map range from 0..1 to range -35..0 dB and calculate linear gain
+        if ( fValue == 0 )
+        {
+            return 0; // -infinity
+        }
+
+        return ( ( AUD_MIX_FADER_RANGE_DB + (20.0f * log10 ( fValue ) ) ) / AUD_MIX_FADER_RANGE_DB ) *  AUD_MIX_FADER_MAX;
+    }
 };
 
 


### PR DESCRIPTION
A proof of concept of broadcasting your mixers, and for others to follow it. This is a prototype to demonstrate the functionality, and it has many missing parts. 

## What it does:

- you can broadcast your mix to all others in the File menu
- others get a nice 'follow' checkbox
- once checked, they follow the mix
- once unchecked, they stop following the mix and can adjust on their own again

This means you will be able to do the following:
- Follow a central mix for a longer time, with the potential for large performance gains
- Quickly copy a mix: follow it, then make any local adjustment - you will auto follow
- or just ignore that there is a central mix broadcasted, and create your own mix 

## What does not yet work

This is all just because this is just a prototype, and needs more work, most of it is not so hard to do.

**Do not expect the following to work**
- connect, disconnect, then connect again with the same jamulus instance. Just restart it
- restart the server with clients connected
- disconnect, then reuse the same channel id with a different client

**And things it does not do, that appear to work:**
- it always follows the broadcasters with the lowest channel id, regardless of which follow button you click
- when unfollowing, it correctly shows your faders as the same as the last state of the followed mix. Serverside, I'm not sure if that's the case

**Things that clearly do not work:**
- layout of the UI is ugly
- it says 'follow <channelID>' instead of 'follow <name>'
- stop broadcasting or disconnecting does stop broadcasting, but followers don't auto-unfollow
- Adjusting your own fader when following should stop following automatically. It does not yet.